### PR TITLE
Issue crossplane 684

### DIFF
--- a/aws/apis/compute/v1alpha2/types.go
+++ b/aws/apis/compute/v1alpha2/types.go
@@ -168,7 +168,7 @@ type MapUser struct {
 //WorkerNodesSpec - Worker node spec used to define cloudformation template that provisions workers for cluster
 type WorkerNodesSpec struct {
 	// KeyName The EC2 Key Pair to allow SSH access to the instances
-	KeyName string `json:"keyName"`
+	KeyName string `json:"keyName,omitempty"`
 
 	// NodeImageId The EC2 Key Pair to allow SSH access to the instances
 	// defaults to region standard AMI

--- a/aws/apis/network/v1alpha2/vpc_types.go
+++ b/aws/apis/network/v1alpha2/vpc_types.go
@@ -27,6 +27,12 @@ type VPCParameters struct {
 	// CIDRBlock is the IPv4 network range for the VPC, in CIDR notation. For example, 10.0.0.0/16.
 	// +kubebuilder:validation:Required
 	CIDRBlock string `json:"cidrBlock"`
+
+	// A boolean flag to enable/disable DNS support in the VPC
+	EnableDNSSupport bool `json:"enableDnsSupport,omitempty"`
+
+	// A boolean flag to enable/disable DNS hostnames in the VPC
+	EnableDNSHostNames bool `json:"enableDnsHostNames,omitempty"`
 }
 
 // VPCSpec defines the desired state of a VPC

--- a/config/crd/compute.aws.crossplane.io_eksclusterclasses.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusterclasses.yaml
@@ -321,7 +321,6 @@ spec:
                   description: 'NodeVolumeSize Node volume size in GB Default: 20'
                   type: integer
               required:
-              - keyName
               - nodeInstanceType
               type: object
           required:

--- a/config/crd/compute.aws.crossplane.io_eksclusters.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusters.yaml
@@ -412,7 +412,6 @@ spec:
                   description: 'NodeVolumeSize Node volume size in GB Default: 20'
                   type: integer
               required:
-              - keyName
               - nodeInstanceType
               type: object
             writeConnectionSecretToRef:

--- a/config/crd/network.aws.crossplane.io_vpcs.yaml
+++ b/config/crd/network.aws.crossplane.io_vpcs.yaml
@@ -135,6 +135,12 @@ spec:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+            enableDnsHostNames:
+              description: A boolean flag to enable/disable DNS hostnames in the VPC
+              type: boolean
+            enableDnsSupport:
+              description: A boolean flag to enable/disable DNS support in the VPC
+              type: boolean
             providerRef:
               description: ProviderReference specifies the provider that will be used
                 to create, observe, update, and delete this managed resource.

--- a/pkg/clients/aws/ec2/fake/vpc.go
+++ b/pkg/clients/aws/ec2/fake/vpc.go
@@ -27,9 +27,10 @@ var _ clientset.VPCClient = (*MockVPCClient)(nil)
 
 // MockVPCClient is a type that implements all the methods for VPCClient interface
 type MockVPCClient struct {
-	MockCreateVpcRequest    func(*ec2.CreateVpcInput) ec2.CreateVpcRequest
-	MockDeleteVpcRequest    func(*ec2.DeleteVpcInput) ec2.DeleteVpcRequest
-	MockDescribeVpcsRequest func(*ec2.DescribeVpcsInput) ec2.DescribeVpcsRequest
+	MockCreateVpcRequest          func(*ec2.CreateVpcInput) ec2.CreateVpcRequest
+	MockDeleteVpcRequest          func(*ec2.DeleteVpcInput) ec2.DeleteVpcRequest
+	MockDescribeVpcsRequest       func(*ec2.DescribeVpcsInput) ec2.DescribeVpcsRequest
+	MockModifyVpcAttributeRequest func(*ec2.ModifyVpcAttributeInput) ec2.ModifyVpcAttributeRequest
 }
 
 // CreateVpcRequest mocks CreateVpcRequest method
@@ -45,4 +46,9 @@ func (m *MockVPCClient) DeleteVpcRequest(input *ec2.DeleteVpcInput) ec2.DeleteVp
 // DescribeVpcsRequest mocks DescribeVpcsRequest method
 func (m *MockVPCClient) DescribeVpcsRequest(input *ec2.DescribeVpcsInput) ec2.DescribeVpcsRequest {
 	return m.MockDescribeVpcsRequest(input)
+}
+
+// ModifyVpcAttributeRequest mocks ModifyVpcAttributeRequest method
+func (m *MockVPCClient) ModifyVpcAttributeRequest(input *ec2.ModifyVpcAttributeInput) ec2.ModifyVpcAttributeRequest {
+	return m.MockModifyVpcAttributeRequest(input)
 }

--- a/pkg/clients/aws/ec2/vpc.go
+++ b/pkg/clients/aws/ec2/vpc.go
@@ -16,6 +16,7 @@ type VPCClient interface {
 	CreateVpcRequest(*ec2.CreateVpcInput) ec2.CreateVpcRequest
 	DeleteVpcRequest(*ec2.DeleteVpcInput) ec2.DeleteVpcRequest
 	DescribeVpcsRequest(*ec2.DescribeVpcsInput) ec2.DescribeVpcsRequest
+	ModifyVpcAttributeRequest(*ec2.ModifyVpcAttributeInput) ec2.ModifyVpcAttributeRequest
 }
 
 // NewVPCClient returns a new client using AWS credentials as JSON encoded data.

--- a/pkg/clients/aws/eks/eks.go
+++ b/pkg/clients/aws/eks/eks.go
@@ -151,7 +151,6 @@ func (e *eksClient) CreateWorkerNodes(name string, clusterVersion string, spec a
 		"ClusterName":                      name,
 		"VpcId":                            spec.VpcID,
 		"Subnets":                          subnetIds,
-		"KeyName":                          spec.WorkerNodes.KeyName,
 		"NodeImageId":                      aws.StringValue(ami.ImageId),
 		"NodeInstanceType":                 spec.WorkerNodes.NodeInstanceType,
 		"BootstrapArguments":               spec.WorkerNodes.BootstrapArguments,
@@ -348,10 +347,6 @@ Description: 'Amazon EKS - Node Group - Released 2018-08-30'
 
 Parameters:
 
-  KeyName:
-    Description: The EC2 Key Pair to allow SSH access to the instances
-    Type: AWS::EC2::KeyPair::KeyName
-
   NodeImageId:
     Type: AWS::EC2::Image::Id
     Description: AMI id for the node instances.
@@ -502,7 +497,6 @@ Metadata:
           - NodeInstanceType
           - NodeImageId
           - NodeVolumeSize
-          - KeyName
           - BootstrapArguments
       -
         Label:
@@ -666,7 +660,6 @@ Resources:
       IamInstanceProfile: !Ref NodeInstanceProfile
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType
-      KeyName: !Ref KeyName
       SecurityGroups:
       - !Ref NodeSecurityGroup
       BlockDeviceMappings:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
Addresses #684
When e2e testing the new managed resources for resource connectivity:

- [KeyName] doesn't need to be a required value. This is used to make it possible to remote login to eks workers, and to avoid unnecessary complexity can be ignored for now. If this turned out to be an actually required feature, a managed resource to create aws KeyPairs need to be developed
- [VPC] type is missing `EnableDNSHostNames` and `EnableDNSSupport` attributes. These attributes are required for RDS connectivity
### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the RBAC permissions in [`clusterrole.yaml`] to include any new types.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`clusterrole.yaml`]: https://github.com/crossplaneio/crossplane/blob/master/cluster/charts/crossplane/templates/clusterrole.yaml

[KeyName]: https://github.com/crossplaneio/stack-aws/blob/master/aws/apis/compute/v1alpha2/types.go#L171
[VPC]: https://github.com/crossplaneio/stack-aws/blob/master/aws/apis/network/v1alpha2/vpc_types.go#L26