### PR TITLE
rds: remove unused  masterpassword field from spec

### DIFF
--- a/apis/database/v1beta1/rdsinstance_types.go
+++ b/apis/database/v1beta1/rdsinstance_types.go
@@ -471,24 +471,6 @@ type RDSInstanceParameters struct {
 	// +optional
 	LicenseModel *string `json:"licenseModel,omitempty"`
 
-	// MasterUserPassword is the password for the master user. The password can include any printable
-	// ASCII character except "/", """, or "@".
-	// Amazon Aurora
-	// Not applicable. The password for the master user is managed by the DB cluster.
-	// For more information, see CreateDBCluster.
-	// MariaDB
-	// Constraints: Must contain from 8 to 41 characters.
-	// Microsoft SQL Server
-	// Constraints: Must contain from 8 to 128 characters.
-	// MySQL
-	// Constraints: Must contain from 8 to 41 characters.
-	// Oracle
-	// Constraints: Must contain from 8 to 30 characters.
-	// PostgreSQL
-	// Constraints: Must contain from 8 to 128 characters.
-	// +optional
-	MasterUserPassword *string `json:"masterUserPassword,omitempty"`
-
 	// MasterUsername is the name for the master user.
 	// Amazon Aurora
 	// Not applicable. The name for the master user is managed by the DB cluster.

--- a/apis/database/v1beta1/zz_generated.deepcopy.go
+++ b/apis/database/v1beta1/zz_generated.deepcopy.go
@@ -591,11 +591,6 @@ func (in *RDSInstanceParameters) DeepCopyInto(out *RDSInstanceParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.MasterUserPassword != nil {
-		in, out := &in.MasterUserPassword, &out.MasterUserPassword
-		*out = new(string)
-		**out = **in
-	}
 	if in.MasterUsername != nil {
 		in, out := &in.MasterUsername, &out.MasterUsername
 		*out = new(string)

--- a/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstanceclasses.yaml
@@ -355,18 +355,6 @@ spec:
                   description: 'LicenseModel information for this DB instance. Valid
                     values: license-included | bring-your-own-license | general-public-license'
                   type: string
-                masterUserPassword:
-                  description: 'MasterUserPassword is the password for the master
-                    user. The password can include any printable ASCII character except
-                    "/", """, or "@". Amazon Aurora Not applicable. The password for
-                    the master user is managed by the DB cluster. For more information,
-                    see CreateDBCluster. MariaDB Constraints: Must contain from 8
-                    to 41 characters. Microsoft SQL Server Constraints: Must contain
-                    from 8 to 128 characters. MySQL Constraints: Must contain from
-                    8 to 41 characters. Oracle Constraints: Must contain from 8 to
-                    30 characters. PostgreSQL Constraints: Must contain from 8 to
-                    128 characters.'
-                  type: string
                 masterUsername:
                   description: 'MasterUsername is the name for the master user. Amazon
                     Aurora Not applicable. The name for the master user is managed

--- a/config/crd/database.aws.crossplane.io_rdsinstances.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstances.yaml
@@ -438,18 +438,6 @@ spec:
                   description: 'LicenseModel information for this DB instance. Valid
                     values: license-included | bring-your-own-license | general-public-license'
                   type: string
-                masterUserPassword:
-                  description: 'MasterUserPassword is the password for the master
-                    user. The password can include any printable ASCII character except
-                    "/", """, or "@". Amazon Aurora Not applicable. The password for
-                    the master user is managed by the DB cluster. For more information,
-                    see CreateDBCluster. MariaDB Constraints: Must contain from 8
-                    to 41 characters. Microsoft SQL Server Constraints: Must contain
-                    from 8 to 128 characters. MySQL Constraints: Must contain from
-                    8 to 41 characters. Oracle Constraints: Must contain from 8 to
-                    30 characters. PostgreSQL Constraints: Must contain from 8 to
-                    128 characters.'
-                  type: string
                 masterUsername:
                   description: 'MasterUsername is the name for the master user. Amazon
                     Aurora Not applicable. The name for the master user is managed


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes

Remove unused  masterpassword field from spec. It's not used anywhere but somehow exists.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-aws/blob/master/config/stack/manifests/app.yaml
