### PR TITLE
Bump stack-aws version refs to v0.4.0

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -18,7 +18,7 @@ echo_sub_step(){
 }
 
 echo_step_completed(){
-    printf "${GRN} [✔]${NOC}" 
+    printf "${GRN} [✔]${NOC}"
 }
 
 echo_success(){
@@ -59,7 +59,7 @@ wait_for_pods_in_namespace(){
     local timeout=$1
     shift
     namespace=$1
-    shift 
+    shift
     arr=("$@")
     local counter=0
     for i in "${arr[@]}";
@@ -85,7 +85,7 @@ check_deployments(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$dep_stat" | awk ' FNR > 1 {print $2}')"
@@ -102,7 +102,7 @@ check_deployments(){
 check_pods(){
     pods=$("${KUBECTL}" -n "$1" get pods)
     echo "$pods"
-    while read -r pod_stat; do 
+    while read -r pod_stat; do
         name=$(echo "$pod_stat" | awk '{print $1}')
         echo_sub_step "inspecting pod '${name}'"
 
@@ -112,7 +112,7 @@ check_pods(){
             echo_info "is completed, foregoing further checks"
             echo_step_completed
             continue
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$pod_stat" | awk '{print $2}')"
@@ -129,7 +129,7 @@ check_pods(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if has restarts"
         if (( $(echo "$pod_stat" | awk '{print $4}') > 0 )); then
@@ -167,7 +167,7 @@ BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
 # tag as master so that config/stack/install.yaml can be used
-STACK_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:master"
+STACK_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:v0.4.0"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-INTTESTS}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -21,7 +21,7 @@ readme: |
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag
 # If set it must match the docker tag
-version: 0.0.1
+version: v0.4.0
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: "stack-aws-controller"
-        image: "crossplane/stack-aws:master"
+        image: "crossplane/stack-aws:v0.4.0"
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/stack/manifests/resources/eksclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/eksclusterclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a managed Kubernetes cluster, which is satisfied by [Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-aws/compute-aws-crossplane-io-v1alpha3.html#EKSClusterClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-aws/compute-aws-crossplane-io-v1alpha3.html#EKSClusterClass).

--- a/config/stack/manifests/resources/provider.resource.yaml
+++ b/config/stack/manifests/resources/provider.resource.yaml
@@ -10,4 +10,4 @@ readme: |
 
  The Crossplane AWS Provider Resource configures an AWS 'provider', i.e. a connection to a particular AWS account using a particular AWS IAM Role.
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-aws/aws-crossplane-io-v1alpha3.html#Provider).
+ Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-aws/aws-crossplane-io-v1alpha3.html#Provider).

--- a/config/stack/manifests/resources/rdsinstanceclass.resource.yaml
+++ b/config/stack/manifests/resources/rdsinstanceclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a relational database, which is satisfied by [Amazon Relational Database Service (RDS)](https://aws.amazon.com/rds/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-aws/database-aws-crossplane-io-v1beta1.html#RDSInstanceClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-aws/database-aws-crossplane-io-v1beta1.html#RDSInstanceClass).

--- a/config/stack/manifests/resources/replicationgroupclass.resource.yaml
+++ b/config/stack/manifests/resources/replicationgroupclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a Redis Replication Group, which is satisfied by [Amazon ElastiCache for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.CreatingRepGroup.html).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-aws/cache-aws-crossplane-io-v1beta1.html#ReplicationGroupClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-aws/cache-aws-crossplane-io-v1beta1.html#ReplicationGroupClass).

--- a/config/stack/manifests/resources/s3bucketclass.resource.yaml
+++ b/config/stack/manifests/resources/s3bucketclass.resource.yaml
@@ -8,4 +8,4 @@ overview: |
 readme: |
  Cloud-specific resource classes are used to define a reusable configuration for a specific managed service. This class provides a object storage bucks, which is satisfied by [AWS S3](https://aws.amazon.com/s3/).
 
- Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-aws/storage-aws-crossplane-io-v1alpha3.html#S3BucketClass).
+ Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-aws/storage-aws-crossplane-io-v1alpha3.html#S3BucketClass).


### PR DESCRIPTION
### Description of your changes

This PR bumps the internal stack references to the soon to be released version of v0.4.0, as well as updating the stack resource readmes to reference the soon to be released crossplane.io docs version 0.6.

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
