### PR TITLE
Go 1.13 / k8s Target / controller-runtime bump

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,6 +133,11 @@ issues:
         - gosec
         - scopelint
         - unparam
+    
+    # Exclude gocyclo on generated files
+    - path: zz_generated\.deepcopy\.go
+      linters:
+        - gocyclo
 
     # Ease some gocritic warnings on test files.
     - path: _test\.go

--- a/apis/cache/v1beta1/register.go
+++ b/apis/cache/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/compute/v1alpha3/register.go
+++ b/apis/compute/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/database/v1alpha3/register.go
+++ b/apis/database/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/database/v1beta1/register.go
+++ b/apis/database/v1beta1/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/identity/v1alpha3/register.go
+++ b/apis/identity/v1alpha3/register.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/network/v1alpha3/register.go
+++ b/apis/network/v1alpha3/register.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/storage/v1alpha3/register.go
+++ b/apis/storage/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/apis/v1alpha3/register.go
+++ b/apis/v1alpha3/register.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 // Package type metadata.

--- a/cmd/stack/main.go
+++ b/cmd/stack/main.go
@@ -23,9 +23,10 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	runtimelog "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	apis "github.com/crossplaneio/stack-aws/apis"
 	"github.com/crossplaneio/stack-aws/pkg/controller"
@@ -50,7 +51,7 @@ func main() {
 	)
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 
-	zl := runtimelog.ZapLogger(*debug)
+	zl := zap.Logger(*debug)
 	logging.SetLogger(zl)
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is

--- a/config/crd/cache.aws.crossplane.io_replicationgroups.yaml
+++ b/config/crd/cache.aws.crossplane.io_replicationgroups.yaml
@@ -651,7 +651,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/compute.aws.crossplane.io_eksclusters.yaml
+++ b/config/crd/compute.aws.crossplane.io_eksclusters.yaml
@@ -488,7 +488,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.aws.crossplane.io_dbsubnetgroups.yaml
+++ b/config/crd/database.aws.crossplane.io_dbsubnetgroups.yaml
@@ -268,7 +268,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/database.aws.crossplane.io_rdsinstances.yaml
+++ b/config/crd/database.aws.crossplane.io_rdsinstances.yaml
@@ -1161,7 +1161,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
+++ b/config/crd/identity.aws.crossplane.io_iamrolepolicyattachments.yaml
@@ -242,7 +242,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/identity.aws.crossplane.io_iamroles.yaml
+++ b/config/crd/identity.aws.crossplane.io_iamroles.yaml
@@ -237,7 +237,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.aws.crossplane.io_internetgateways.yaml
+++ b/config/crd/network.aws.crossplane.io_internetgateways.yaml
@@ -257,7 +257,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.aws.crossplane.io_routetables.yaml
+++ b/config/crd/network.aws.crossplane.io_routetables.yaml
@@ -304,7 +304,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.aws.crossplane.io_securitygroups.yaml
+++ b/config/crd/network.aws.crossplane.io_securitygroups.yaml
@@ -352,7 +352,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.aws.crossplane.io_subnets.yaml
+++ b/config/crd/network.aws.crossplane.io_subnets.yaml
@@ -250,7 +250,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/network.aws.crossplane.io_vpcs.yaml
+++ b/config/crd/network.aws.crossplane.io_vpcs.yaml
@@ -234,7 +234,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/config/crd/storage.aws.crossplane.io_s3buckets.yaml
+++ b/config/crd/storage.aws.crossplane.io_s3buckets.yaml
@@ -250,7 +250,7 @@ spec:
             conditions:
               description: Conditions of the resource.
               items:
-                description: A Condition that may apply to a managed resource.
+                description: A Condition that may apply to a resource.
                 properties:
                   lastTransitionTime:
                     description: LastTransitionTime is the last time this condition

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplaneio/stack-aws
 
-go 1.12
+go 1.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go-v2 v0.5.0
-	github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0
-	github.com/crossplaneio/crossplane-runtime v0.3.0
+	github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6
+	github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3
 	github.com/crossplaneio/crossplane-tools v0.0.0-20191220202319-9033bd8a02ce
 	github.com/evanphx/json-patch v4.5.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,17 @@ github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0 h1:Sp1jDkEaEuJyXQzmU+fT4GVdlynzblXslHE/+DbJ3jg=
 github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0/go.mod h1:lW/xhJfNx5QQve/9xH2JszMqtSfVlEQBtKE0u96qlCI=
+github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6 h1:GWyXwoVIMItJUqhIxjx0X8hcnkYtzSnDWbbmoUsjWN4=
+github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6/go.mod h1:8V5faxSOvBejN2Rlaw6g7ZwyqxkMkeD72TpNjOKmkks=
 github.com/crossplaneio/crossplane-runtime v0.3.0 h1:d3937o6XhVUcm/bqgUPUjTo/OjVlAjh1c7rx4VPJoV8=
 github.com/crossplaneio/crossplane-runtime v0.3.0/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200114203641-5ece4af54b32/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115205235-96f34341723c h1:5yPpo7lbsVM9w8ZhUn3meCZ7/SorNi9gNEj5WmIbDr4=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115205235-96f34341723c/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115221456-e0d566ed82b8 h1:QCsdpaVpRBRNRFjdht7z5F0oWcAz4xCleZZ4wsfr19U=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115221456-e0d566ed82b8/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3 h1:S7eTG5kLDUOp1ddUkO7wajPH8HEun1LZRyJLuKu/PhU=
+github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191023215726-61fa1eff2a2e h1:8Z29akSDYcbywc/brATpfeE425jBTMZdZQuD9eV6cCk=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191023215726-61fa1eff2a2e/go.mod h1:fzQeWDvZvzaC4N8vPjTubQocGnwzQ4cuZM6949+T43U=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191220202319-9033bd8a02ce h1:V7cUPRBxbJr0siRHn459gb6hfMXaEA+pGm0Yt5aXdhQ=

--- a/go.sum
+++ b/go.sum
@@ -57,17 +57,9 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
-github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0 h1:Sp1jDkEaEuJyXQzmU+fT4GVdlynzblXslHE/+DbJ3jg=
-github.com/crossplaneio/crossplane v0.6.0-rc.0.20191226165033-a452562456e0/go.mod h1:lW/xhJfNx5QQve/9xH2JszMqtSfVlEQBtKE0u96qlCI=
 github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6 h1:GWyXwoVIMItJUqhIxjx0X8hcnkYtzSnDWbbmoUsjWN4=
 github.com/crossplaneio/crossplane v0.6.0-rc.0.20200115221822-c06433fc39c6/go.mod h1:8V5faxSOvBejN2Rlaw6g7ZwyqxkMkeD72TpNjOKmkks=
-github.com/crossplaneio/crossplane-runtime v0.3.0 h1:d3937o6XhVUcm/bqgUPUjTo/OjVlAjh1c7rx4VPJoV8=
-github.com/crossplaneio/crossplane-runtime v0.3.0/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
 github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200114203641-5ece4af54b32/go.mod h1:aVLQmXiPeb/jhGGQFIxx4Rc1CFC6xq2BA6A3neLZIHA=
-github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115205235-96f34341723c h1:5yPpo7lbsVM9w8ZhUn3meCZ7/SorNi9gNEj5WmIbDr4=
-github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115205235-96f34341723c/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
-github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115221456-e0d566ed82b8 h1:QCsdpaVpRBRNRFjdht7z5F0oWcAz4xCleZZ4wsfr19U=
-github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115221456-e0d566ed82b8/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
 github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3 h1:S7eTG5kLDUOp1ddUkO7wajPH8HEun1LZRyJLuKu/PhU=
 github.com/crossplaneio/crossplane-runtime v0.3.1-0.20200115232149-cd8c52b483c3/go.mod h1:UTemZ8u+bvHkQMHpdsZ2z/dTHC7tRkXc2K6Z9N26KQI=
 github.com/crossplaneio/crossplane-tools v0.0.0-20191023215726-61fa1eff2a2e h1:8Z29akSDYcbywc/brATpfeE425jBTMZdZQuD9eV6cCk=

--- a/pkg/clients/elasticache/elasticache.go
+++ b/pkg/clients/elasticache/elasticache.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 
 	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
@@ -317,13 +317,13 @@ func newEndpoint(e *elasticache.Endpoint) v1beta1.Endpoint {
 
 // ConnectionEndpoint returns the connection endpoint for a Replication Group.
 // https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html
-func ConnectionEndpoint(rg elasticache.ReplicationGroup) resource.ConnectionDetails {
+func ConnectionEndpoint(rg elasticache.ReplicationGroup) managed.ConnectionDetails {
 	// "Cluster enabled" Replication Groups have multiple node groups, and an
 	// explicit configuration endpoint that should be used for read and write.
 	if aws.BoolValue(rg.ClusterEnabled) &&
 		rg.ConfigurationEndpoint != nil &&
 		rg.ConfigurationEndpoint.Address != nil {
-		return resource.ConnectionDetails{
+		return managed.ConnectionDetails{
 			v1alpha1.ResourceCredentialsSecretEndpointKey: []byte(aws.StringValue(rg.ConfigurationEndpoint.Address)),
 			v1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(int(aws.Int64Value(rg.ConfigurationEndpoint.Port)))),
 		}
@@ -336,7 +336,7 @@ func ConnectionEndpoint(rg elasticache.ReplicationGroup) resource.ConnectionDeta
 	if len(rg.NodeGroups) > 0 &&
 		rg.NodeGroups[0].PrimaryEndpoint != nil &&
 		rg.NodeGroups[0].PrimaryEndpoint.Address != nil {
-		return resource.ConnectionDetails{
+		return managed.ConnectionDetails{
 			v1alpha1.ResourceCredentialsSecretEndpointKey: []byte(aws.StringValue(rg.NodeGroups[0].PrimaryEndpoint.Address)),
 			v1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(int(aws.Int64Value(rg.NodeGroups[0].PrimaryEndpoint.Port)))),
 		}

--- a/pkg/clients/elasticache/elasticache_test.go
+++ b/pkg/clients/elasticache/elasticache_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/google/go-cmp/cmp"
@@ -773,7 +773,7 @@ func TestConnectionEndpoint(t *testing.T) {
 	cases := []struct {
 		name string
 		rg   elasticache.ReplicationGroup
-		want resource.ConnectionDetails
+		want managed.ConnectionDetails
 	}{
 		{
 			name: "ClusterModeEnabled",
@@ -784,7 +784,7 @@ func TestConnectionEndpoint(t *testing.T) {
 					Port:    aws.Int64(port),
 				},
 			},
-			want: resource.ConnectionDetails{
+			want: managed.ConnectionDetails{
 				v1alpha1.ResourceCredentialsSecretEndpointKey: []byte(host),
 				v1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(port)),
 			},
@@ -806,7 +806,7 @@ func TestConnectionEndpoint(t *testing.T) {
 					}},
 				},
 			},
-			want: resource.ConnectionDetails{
+			want: managed.ConnectionDetails{
 				v1alpha1.ResourceCredentialsSecretEndpointKey: []byte(host),
 				v1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(port)),
 			},

--- a/pkg/clients/rds/rds.go
+++ b/pkg/clients/rds/rds.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	"github.com/crossplaneio/stack-aws/apis/database/v1beta1"
@@ -444,12 +445,12 @@ func IsUpToDate(p v1beta1.RDSInstanceParameters, db rds.DBInstance) (bool, error
 	return cmp.Equal(&v1beta1.RDSInstanceParameters{}, patch, cmpopts.IgnoreInterfaces(struct{ resource.AttributeReferencer }{})), nil
 }
 
-// GetConnectionDetails extracts resource.ConnectionDetails out of v1alpha3.RDSInstance.
-func GetConnectionDetails(in v1beta1.RDSInstance) resource.ConnectionDetails {
+// GetConnectionDetails extracts managed.ConnectionDetails out of v1alpha3.RDSInstance.
+func GetConnectionDetails(in v1beta1.RDSInstance) managed.ConnectionDetails {
 	if in.Status.AtProvider.Endpoint.Address == "" {
 		return nil
 	}
-	return resource.ConnectionDetails{
+	return managed.ConnectionDetails{
 		v1alpha1.ResourceCredentialsSecretEndpointKey: []byte(in.Status.AtProvider.Endpoint.Address),
 		v1alpha1.ResourceCredentialsSecretPortKey:     []byte(strconv.Itoa(in.Status.AtProvider.Endpoint.Port)),
 	}

--- a/pkg/controller/cache/claim.go
+++ b/pkg/controller/cache/claim.go
@@ -29,6 +29,9 @@ import (
 	aws "github.com/crossplaneio/stack-aws/pkg/clients"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	cachev1alpha1 "github.com/crossplaneio/crossplane/apis/cache/v1alpha1"
 )
@@ -54,7 +57,7 @@ func (c *ReplicationGroupClaimSchedulingController) SetupWithManager(mgr ctrl.Ma
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 			resource.ClassKind(v1beta1.ReplicationGroupClassGroupVersionKind),
 		))
@@ -81,7 +84,7 @@ func (c *ReplicationGroupClaimDefaultingController) SetupWithManager(mgr ctrl.Ma
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 			resource.ClassKind(v1beta1.ReplicationGroupClassGroupVersionKind),
 		))
@@ -98,14 +101,14 @@ func (c *ReplicationGroupClaimController) SetupWithManager(mgr ctrl.Manager) err
 		v1beta1.ReplicationGroupKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(cachev1alpha1.RedisClusterGroupVersionKind),
 		resource.ClassKind(v1beta1.ReplicationGroupClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.ReplicationGroupGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureReplicationGroup),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureReplicationGroup),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/cache/claim_test.go
+++ b/pkg/controller/cache/claim_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	cachev1alpha1 "github.com/crossplaneio/crossplane/apis/cache/v1alpha1"
@@ -41,8 +42,8 @@ const (
 )
 
 var (
-	_                 resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureReplicationGroup)
-	awsClassVersion32                              = string(v1beta1.LatestSupportedPatchVersion[claimVersion32])
+	_                 claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureReplicationGroup)
+	awsClassVersion32                                  = string(v1beta1.LatestSupportedPatchVersion[claimVersion32])
 )
 
 func TestConfigureReplicationGroup(t *testing.T) {

--- a/pkg/controller/cache/managed_test.go
+++ b/pkg/controller/cache/managed_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/crossplaneio/crossplane-runtime/pkg/meta"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
@@ -42,7 +43,6 @@ import (
 	"github.com/crossplaneio/stack-aws/pkg/clients/elasticache/fake"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 )
 
@@ -100,7 +100,7 @@ var (
 
 type testCase struct {
 	name         string
-	e            resource.ExternalClient
+	e            managed.ExternalClient
 	r            *v1beta1.ReplicationGroup
 	want         *v1beta1.ReplicationGroup
 	tokenCreated bool
@@ -181,8 +181,8 @@ func replicationGroup(rm ...replicationGroupModifier) *v1beta1.ReplicationGroup 
 }
 
 // Test that our Reconciler implementation satisfies the Reconciler interface.
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connecter{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connecter{}
 
 func TestCreate(t *testing.T) {
 	cases := []testCase{

--- a/pkg/controller/compute/claim.go
+++ b/pkg/controller/compute/claim.go
@@ -28,6 +28,9 @@ import (
 	"github.com/crossplaneio/stack-aws/apis/compute/v1alpha3"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	computev1alpha1 "github.com/crossplaneio/crossplane/apis/compute/v1alpha1"
 )
@@ -53,7 +56,7 @@ func (c *EKSClusterClaimSchedulingController) SetupWithManager(mgr ctrl.Manager)
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 			resource.ClassKind(v1alpha3.EKSClusterClassGroupVersionKind),
 		))
@@ -80,7 +83,7 @@ func (c *EKSClusterClaimDefaultingController) SetupWithManager(mgr ctrl.Manager)
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 			resource.ClassKind(v1alpha3.EKSClusterClassGroupVersionKind),
 		))
@@ -97,15 +100,15 @@ func (c *EKSClusterClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1alpha3.EKSClusterKind,
 		v1alpha3.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(computev1alpha1.KubernetesClusterGroupVersionKind),
 		resource.ClassKind(v1alpha3.EKSClusterClassGroupVersionKind),
 		resource.ManagedKind(v1alpha3.EKSClusterGroupVersionKind),
-		resource.WithBinder(resource.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureEKSCluster),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithBinder(claimbinding.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureEKSCluster),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/compute/claim_test.go
+++ b/pkg/controller/compute/claim_test.go
@@ -28,12 +28,13 @@ import (
 	"github.com/crossplaneio/stack-aws/apis/compute/v1alpha3"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	computev1alpha1 "github.com/crossplaneio/crossplane/apis/compute/v1alpha1"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureEKSCluster)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureEKSCluster)
 
 func TestConfigureEKSCluster(t *testing.T) {
 	type args struct {

--- a/pkg/controller/compute/secret.go
+++ b/pkg/controller/compute/secret.go
@@ -24,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/secret"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane/apis/compute/v1alpha1"
 
@@ -44,8 +45,8 @@ func (c *EKSClusterSecretController) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(strings.ToLower(fmt.Sprintf("connectionsecret.%s.%s", v1alpha3.EKSClusterKind, v1alpha3.Group))).
-		Watches(&source.Kind{Type: &corev1.Secret{}}, &resource.EnqueueRequestForPropagator{}).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, &resource.EnqueueRequestForPropagated{}).
 		For(&corev1.Secret{}).
 		WithEventFilter(p).
-		Complete(resource.NewSecretPropagatingReconciler(mgr))
+		Complete(secret.NewReconciler(mgr))
 }

--- a/pkg/controller/compute/target.go
+++ b/pkg/controller/compute/target.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compute
+
+import (
+	"fmt"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/target"
+	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane/apis/workload/v1alpha1"
+
+	"github.com/crossplaneio/stack-aws/apis/compute/v1alpha3"
+)
+
+// EKSClusterTargetController is responsible for adding the EKSCluster target
+// controller and its corresponding reconciler to the manager with any runtime configuration.
+type EKSClusterTargetController struct{}
+
+// SetupWithManager adds a controller that propagates EKSCluster connection
+// secrets to the connection secrets of their targets.
+func (c *EKSClusterTargetController) SetupWithManager(mgr ctrl.Manager) error {
+	p := resource.NewPredicates(resource.HasManagedResourceReferenceKind(resource.ManagedKind(v1alpha3.EKSClusterGroupVersionKind)))
+
+	r := target.NewReconciler(mgr,
+		resource.TargetKind(v1alpha1.KubernetesTargetGroupVersionKind),
+		resource.ManagedKind(v1alpha3.EKSClusterGroupVersionKind))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(strings.ToLower(fmt.Sprintf("kubernetestarget.%s.%s", v1alpha3.EKSClusterKind, v1alpha3.Group))).
+		For(&v1alpha1.KubernetesTarget{}).
+		WithEventFilter(p).
+		Complete(r)
+}

--- a/pkg/controller/database/claim.go
+++ b/pkg/controller/database/claim.go
@@ -30,6 +30,9 @@ import (
 	"github.com/crossplaneio/stack-aws/apis/database/v1beta1"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
 )
@@ -55,7 +58,7 @@ func (c *PostgreSQLInstanceClaimSchedulingController) SetupWithManager(mgr ctrl.
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		))
@@ -82,7 +85,7 @@ func (c *PostgreSQLInstanceClaimDefaultingController) SetupWithManager(mgr ctrl.
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		))
@@ -99,14 +102,14 @@ func (c *PostgreSQLInstanceClaimController) SetupWithManager(mgr ctrl.Manager) e
 		v1beta1.RDSInstanceKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.PostgreSQLInstanceGroupVersionKind),
 		resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.RDSInstanceGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigurePostgreRDSInstance),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigurePostgreRDSInstance),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(
@@ -188,7 +191,7 @@ func (c *MySQLInstanceClaimSchedulingController) SetupWithManager(mgr ctrl.Manag
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		))
@@ -215,7 +218,7 @@ func (c *MySQLInstanceClaimDefaultingController) SetupWithManager(mgr ctrl.Manag
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 			resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		))
@@ -232,14 +235,14 @@ func (c *MySQLInstanceClaimController) SetupWithManager(mgr ctrl.Manager) error 
 		v1beta1.RDSInstanceKind,
 		v1beta1.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(databasev1alpha1.MySQLInstanceGroupVersionKind),
 		resource.ClassKind(v1beta1.RDSInstanceClassGroupVersionKind),
 		resource.ManagedKind(v1beta1.RDSInstanceGroupVersionKind),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureMyRDSInstance),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureMyRDSInstance),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/database/claim_test.go
+++ b/pkg/controller/database/claim_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	databasev1alpha1 "github.com/crossplaneio/crossplane/apis/database/v1alpha1"
@@ -40,8 +41,8 @@ const (
 )
 
 var (
-	_ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigurePostgreRDSInstance)
-	_ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureMyRDSInstance)
+	_ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigurePostgreRDSInstance)
+	_ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureMyRDSInstance)
 )
 
 func TestConfigurePostgreRDSInstance(t *testing.T) {

--- a/pkg/controller/database/dbsubnetgroup/controller_test.go
+++ b/pkg/controller/database/dbsubnetgroup/controller_test.go
@@ -229,7 +229,8 @@ func Test_Create(t *testing.T) {
 				DBSubnetGroupName:        "arbitrary group name",
 				SubnetIDs:                []string{"subnetid1", "subnetid2"},
 				Tags: []v1alpha3.Tag{
-					{"tagKey1", "tagValue1"}, {"tagKey2", "tagValue2"},
+					{Key: "tagKey1", Value: "tagValue1"},
+					{Key: "tagKey2", Value: "tagValue2"},
 				},
 			},
 		},

--- a/pkg/controller/database/rdsinstance_test.go
+++ b/pkg/controller/database/rdsinstance_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 
 	"github.com/crossplaneio/stack-aws/apis/database/v1beta1"
@@ -99,8 +99,8 @@ func instance(m ...rdsModifier) *v1beta1.RDSInstance {
 	return cr
 }
 
-var _ resource.ExternalClient = &external{}
-var _ resource.ExternalConnecter = &connector{}
+var _ managed.ExternalClient = &external{}
+var _ managed.ExternalConnecter = &connector{}
 
 func TestConnect(t *testing.T) {
 	secret := corev1.Secret{
@@ -216,7 +216,7 @@ func TestConnect(t *testing.T) {
 func TestObserve(t *testing.T) {
 	type want struct {
 		cr     *v1beta1.RDSInstance
-		result resource.ExternalObservation
+		result managed.ExternalObservation
 		err    error
 	}
 
@@ -246,7 +246,7 @@ func TestObserve(t *testing.T) {
 					withConditions(runtimev1alpha1.Available()),
 					withBindingPhase(runtimev1alpha1.BindingPhaseUnbound),
 					withDBInstanceStatus(string(v1beta1.RDSInstanceStateAvailable))),
-				result: resource.ExternalObservation{
+				result: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  true,
 					ConnectionDetails: rds.GetConnectionDetails(v1beta1.RDSInstance{}),
@@ -274,7 +274,7 @@ func TestObserve(t *testing.T) {
 				cr: instance(
 					withConditions(runtimev1alpha1.Deleting()),
 					withDBInstanceStatus(string(v1beta1.RDSInstanceStateDeleting))),
-				result: resource.ExternalObservation{
+				result: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  true,
 					ConnectionDetails: rds.GetConnectionDetails(v1beta1.RDSInstance{}),
@@ -302,7 +302,7 @@ func TestObserve(t *testing.T) {
 				cr: instance(
 					withConditions(runtimev1alpha1.Unavailable()),
 					withDBInstanceStatus(string(v1beta1.RDSInstanceStateFailed))),
-				result: resource.ExternalObservation{
+				result: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  true,
 					ConnectionDetails: rds.GetConnectionDetails(v1beta1.RDSInstance{}),
@@ -367,7 +367,7 @@ func TestObserve(t *testing.T) {
 					withDBInstanceStatus(string(v1beta1.RDSInstanceStateCreating)),
 					withConditions(runtimev1alpha1.Creating()),
 				),
-				result: resource.ExternalObservation{
+				result: managed.ExternalObservation{
 					ResourceExists:    true,
 					ResourceUpToDate:  true,
 					ConnectionDetails: rds.GetConnectionDetails(v1beta1.RDSInstance{}),
@@ -425,7 +425,7 @@ func TestObserve(t *testing.T) {
 func TestCreate(t *testing.T) {
 	type want struct {
 		cr     *v1beta1.RDSInstance
-		result resource.ExternalCreation
+		result managed.ExternalCreation
 		err    error
 	}
 
@@ -448,8 +448,8 @@ func TestCreate(t *testing.T) {
 				cr: instance(
 					withMasterUsername(&masterUsername),
 					withConditions(runtimev1alpha1.Creating())),
-				result: resource.ExternalCreation{
-					ConnectionDetails: resource.ConnectionDetails{
+				result: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretUserKey:     []byte(masterUsername),
 						runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(replaceMe),
 					},
@@ -481,8 +481,8 @@ func TestCreate(t *testing.T) {
 				cr: instance(
 					withMasterUsername(nil),
 					withConditions(runtimev1alpha1.Creating())),
-				result: resource.ExternalCreation{
-					ConnectionDetails: resource.ConnectionDetails{
+				result: managed.ExternalCreation{
+					ConnectionDetails: managed.ConnectionDetails{
 						runtimev1alpha1.ResourceCredentialsSecretPasswordKey: []byte(replaceMe),
 					},
 				},
@@ -531,7 +531,7 @@ func TestCreate(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	type want struct {
 		cr     *v1beta1.RDSInstance
-		result resource.ExternalUpdate
+		result managed.ExternalUpdate
 		err    error
 	}
 

--- a/pkg/controller/network/internetgateway/controller.go
+++ b/pkg/controller/network/internetgateway/controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	v1alpha3 "github.com/crossplaneio/stack-aws/apis/network/v1alpha3"
@@ -53,10 +54,10 @@ type Controller struct{}
 // SetupWithManager creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
-	r := resource.NewManagedReconciler(mgr,
+	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha3.InternetGatewayGroupVersionKind),
-		resource.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewInternetGatewayClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
-		resource.WithManagedConnectionPublishers())
+		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewInternetGatewayClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
+		managed.WithConnectionPublishers())
 	name := strings.ToLower(fmt.Sprintf("%s.%s", v1alpha3.InternetGatewayKindAPIVersion, v1alpha3.Group))
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -70,7 +71,7 @@ type connector struct {
 	awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
 }
 
-func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (resource.ExternalClient, error) {
+func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mgd.(*v1alpha3.InternetGateway)
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
@@ -93,17 +94,17 @@ type external struct {
 	client ec2.InternetGatewayClient
 }
 
-func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) {
 	cr, ok := mgd.(*v1alpha3.InternetGateway)
 	if !ok {
-		return resource.ExternalObservation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
 	// To find out whether an InternetGateway exist:
 	// - the object's ExternalState should have internetGatewayID populated
 	// - an InternetGateway with the given internetGatewayID should exist
 	if cr.Status.InternetGatewayID == "" {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
@@ -116,18 +117,18 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 	response, err := req.Send()
 
 	if ec2.IsInternetGatewayNotFoundErr(err) {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
 	if err != nil {
-		return resource.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.InternetGatewayID)
+		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.InternetGatewayID)
 	}
 
 	// in a successful response, there should be one and only one object
 	if len(response.InternetGateways) != 1 {
-		return resource.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.InternetGatewayID)
+		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.InternetGatewayID)
 	}
 
 	observed := response.InternetGateways[0]
@@ -147,16 +148,16 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 
 	cr.UpdateExternalStatus(observed)
 
-	return resource.ExternalObservation{
+	return managed.ExternalObservation{
 		ResourceExists:    true,
-		ConnectionDetails: resource.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
 }
 
-func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.ExternalCreation, error) {
+func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.ExternalCreation, error) {
 	cr, ok := mgd.(*v1alpha3.InternetGateway)
 	if !ok {
-		return resource.ExternalCreation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
 	cr.Status.SetConditions(runtimev1alpha1.Creating())
@@ -166,7 +167,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 	ig, err := req.Send()
 	if err != nil {
-		return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
 
 	cr.UpdateExternalStatus(*ig.InternetGateway)
@@ -180,14 +181,14 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 	_, err = aReq.Send()
 
-	return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+	return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 }
 
-func (e *external) Update(ctx context.Context, mgd resource.Managed) (resource.ExternalUpdate, error) {
+func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
 	// TODO(soorena776): add more sophisticated Update logic, once we
 	// categorize immutable vs mutable fields (see #727)
 
-	return resource.ExternalUpdate{}, nil
+	return managed.ExternalUpdate{}, nil
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {

--- a/pkg/controller/network/routetable/controller.go
+++ b/pkg/controller/network/routetable/controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	v1alpha3 "github.com/crossplaneio/stack-aws/apis/network/v1alpha3"
@@ -56,10 +57,10 @@ type Controller struct{}
 // SetupWithManager creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
-	r := resource.NewManagedReconciler(mgr,
+	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha3.RouteTableGroupVersionKind),
-		resource.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewRouteTableClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
-		resource.WithManagedConnectionPublishers())
+		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewRouteTableClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
+		managed.WithConnectionPublishers())
 	name := strings.ToLower(fmt.Sprintf("%s.%s", v1alpha3.RouteTableKindAPIVersion, v1alpha3.Group))
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -73,7 +74,7 @@ type connector struct {
 	awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
 }
 
-func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (resource.ExternalClient, error) {
+func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mgd.(*v1alpha3.RouteTable)
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
@@ -96,17 +97,17 @@ type external struct {
 	client ec2.RouteTableClient
 }
 
-func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) {
 	cr, ok := mgd.(*v1alpha3.RouteTable)
 	if !ok {
-		return resource.ExternalObservation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
 	// To find out whether a RouteTable exist:
 	// - the object's ExternalState should have routeTableId populated
 	// - a RouteTable with the given routeTableId should exist
 	if cr.Status.RouteTableID == "" {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
@@ -119,18 +120,18 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 	response, err := req.Send()
 
 	if ec2.IsRouteTableNotFoundErr(err) {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
 	if err != nil {
-		return resource.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.RouteTableID)
+		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.RouteTableID)
 	}
 
 	// in a successful response, there should be one and only one object
 	if len(response.RouteTables) != 1 {
-		return resource.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.RouteTableID)
+		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.RouteTableID)
 	}
 
 	observed := response.RouteTables[0]
@@ -148,16 +149,16 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 
 	cr.UpdateExternalStatus(observed)
 
-	return resource.ExternalObservation{
+	return managed.ExternalObservation{
 		ResourceExists:    true,
-		ConnectionDetails: resource.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
 }
 
-func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.ExternalCreation, error) { // nolint:gocyclo
+func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.ExternalCreation, error) { // nolint:gocyclo
 	cr, ok := mgd.(*v1alpha3.RouteTable)
 	if !ok {
-		return resource.ExternalCreation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
 	cr.Status.SetConditions(runtimev1alpha1.Creating())
@@ -168,29 +169,29 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 	req.SetContext(ctx)
 	result, err := req.Send()
 	if err != nil {
-		return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
 
 	cr.UpdateExternalStatus(*result.RouteTable)
 
 	// Create Routes
 	if err := e.createRoutes(ctx, cr.Status.RouteTableID, cr.Spec.Routes, cr.Status.Routes); err != nil {
-		return resource.ExternalCreation{}, err
+		return managed.ExternalCreation{}, err
 	}
 
 	// Create Associations
 	if err := e.createAssociations(ctx, cr.Status.RouteTableID, cr.Spec.Associations, cr.Status.Associations); err != nil {
-		return resource.ExternalCreation{}, err
+		return managed.ExternalCreation{}, err
 	}
 
-	return resource.ExternalCreation{}, nil
+	return managed.ExternalCreation{}, nil
 }
 
-func (e *external) Update(ctx context.Context, mgd resource.Managed) (resource.ExternalUpdate, error) {
+func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
 	// TODO(soorena776): add more sophisticated Update logic, once we
 	// categorize immutable vs mutable fields (see #727)
 
-	return resource.ExternalUpdate{}, nil
+	return managed.ExternalUpdate{}, nil
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {

--- a/pkg/controller/network/securitygroup/controller.go
+++ b/pkg/controller/network/securitygroup/controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	v1alpha3 "github.com/crossplaneio/stack-aws/apis/network/v1alpha3"
@@ -54,10 +55,10 @@ type Controller struct{}
 // SetupWithManager creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
-	r := resource.NewManagedReconciler(mgr,
+	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha3.SecurityGroupGroupVersionKind),
-		resource.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewSecurityGroupClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
-		resource.WithManagedConnectionPublishers())
+		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewSecurityGroupClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
+		managed.WithConnectionPublishers())
 	name := strings.ToLower(fmt.Sprintf("%s.%s", v1alpha3.SecurityGroupKindAPIVersion, v1alpha3.Group))
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -71,7 +72,7 @@ type connector struct {
 	awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
 }
 
-func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (resource.ExternalClient, error) {
+func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mgd.(*v1alpha3.SecurityGroup)
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
@@ -94,17 +95,17 @@ type external struct {
 	client ec2.SecurityGroupClient
 }
 
-func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) {
 	cr, ok := mgd.(*v1alpha3.SecurityGroup)
 	if !ok {
-		return resource.ExternalObservation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
 	// To find out whether a SecurityGroup exist:
 	// - the object's ExternalState should have securityGroupId populated
 	// - a SecurityGroup with the given securityGroupId should exist
 	if cr.Status.SecurityGroupID == "" {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
@@ -117,18 +118,18 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 	response, err := req.Send()
 
 	if ec2.IsSecurityGroupNotFoundErr(err) {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
 	if err != nil {
-		return resource.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.SecurityGroupID)
+		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.SecurityGroupID)
 	}
 
 	// in a successful response, there should be one and only one object
 	if len(response.SecurityGroups) != 1 {
-		return resource.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.SecurityGroupID)
+		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.SecurityGroupID)
 	}
 
 	observed := response.SecurityGroups[0]
@@ -139,16 +140,16 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 
 	cr.UpdateExternalStatus(observed)
 
-	return resource.ExternalObservation{
+	return managed.ExternalObservation{
 		ResourceExists:    true,
-		ConnectionDetails: resource.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
 }
 
-func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.ExternalCreation, error) {
+func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.ExternalCreation, error) {
 	cr, ok := mgd.(*v1alpha3.SecurityGroup)
 	if !ok {
-		return resource.ExternalCreation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
 	cr.Status.SetConditions(runtimev1alpha1.Creating())
@@ -163,13 +164,13 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 	result, err := req.Send()
 	if err != nil {
-		return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
 
 	cr.UpdateExternalStatus(awsec2.SecurityGroup{GroupId: result.GroupId})
 
 	if err != nil {
-		return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
 
 	// Authorizing Ingress permissions for the SecurityGroup
@@ -183,7 +184,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 		_, err = air.Send()
 		if err != nil {
-			return resource.ExternalCreation{}, errors.Wrap(err, errAuthorizeIngress)
+			return managed.ExternalCreation{}, errors.Wrap(err, errAuthorizeIngress)
 		}
 	}
 
@@ -198,18 +199,18 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 		_, err = aer.Send()
 		if err != nil {
-			return resource.ExternalCreation{}, errors.Wrap(err, errAuthorizeEgress)
+			return managed.ExternalCreation{}, errors.Wrap(err, errAuthorizeEgress)
 		}
 	}
 
-	return resource.ExternalCreation{}, nil
+	return managed.ExternalCreation{}, nil
 }
 
-func (e *external) Update(ctx context.Context, mgd resource.Managed) (resource.ExternalUpdate, error) {
+func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
 	// TODO(soorena776): add more sophisticated Update logic, once we
 	// categorize immutable vs mutable fields (see #727)
 
-	return resource.ExternalUpdate{}, nil
+	return managed.ExternalUpdate{}, nil
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {

--- a/pkg/controller/network/securitygroup/controller_test.go
+++ b/pkg/controller/network/securitygroup/controller_test.go
@@ -243,8 +243,8 @@ func Test_Create(t *testing.T) {
 						IPProtocol: "an arbitrary protocol",
 						CIDRBlocks: []v1alpha3.IPRange{
 							{
-								"0.0.0.0/0",
-								"an arbitrary cidr block",
+								CIDRIP:      "0.0.0.0/0",
+								Description: "an arbitrary cidr block",
 							},
 						},
 					}, {}, {},
@@ -256,8 +256,8 @@ func Test_Create(t *testing.T) {
 						IPProtocol: "an arbitrary protocol",
 						CIDRBlocks: []v1alpha3.IPRange{
 							{
-								"0.0.0.0/0",
-								"an arbitrary cidr block",
+								CIDRIP:      "0.0.0.0/0",
+								Description: "an arbitrary cidr block",
 							},
 						},
 					}, {},

--- a/pkg/controller/network/vpc/controller.go
+++ b/pkg/controller/network/vpc/controller.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 
 	v1alpha3 "github.com/crossplaneio/stack-aws/apis/network/v1alpha3"
@@ -53,10 +54,10 @@ type Controller struct{}
 // SetupWithManager creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
-	r := resource.NewManagedReconciler(mgr,
+	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha3.VPCGroupVersionKind),
-		resource.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewVPCClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
-		resource.WithManagedConnectionPublishers())
+		managed.WithExternalConnecter(&connector{client: mgr.GetClient(), newClientFn: ec2.NewVPCClient, awsConfigFn: utils.RetrieveAwsConfigFromProvider}),
+		managed.WithConnectionPublishers())
 	name := strings.ToLower(fmt.Sprintf("%s.%s", v1alpha3.VPCKindAPIVersion, v1alpha3.Group))
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -70,7 +71,7 @@ type connector struct {
 	awsConfigFn func(context.Context, client.Reader, *corev1.ObjectReference) (*aws.Config, error)
 }
 
-func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (resource.ExternalClient, error) {
+func (conn *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.ExternalClient, error) {
 	cr, ok := mgd.(*v1alpha3.VPC)
 	if !ok {
 		return nil, errors.New(errUnexpectedObject)
@@ -92,17 +93,17 @@ type external struct {
 	client ec2.VPCClient
 }
 
-func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.ExternalObservation, error) {
 	cr, ok := mgd.(*v1alpha3.VPC)
 	if !ok {
-		return resource.ExternalObservation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)
 	}
 
 	// To find out whether a VPC exist:
 	// - the object's ExternalState should have vpcId populated
 	// - a VPC with the given vpcId should exist
 	if cr.Status.VPCID == "" {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
@@ -115,18 +116,18 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 	response, err := req.Send()
 
 	if ec2.IsVPCNotFoundErr(err) {
-		return resource.ExternalObservation{
+		return managed.ExternalObservation{
 			ResourceExists: false,
 		}, nil
 	}
 
 	if err != nil {
-		return resource.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.VPCID)
+		return managed.ExternalObservation{}, errors.Wrapf(err, errDescribe, cr.Status.VPCID)
 	}
 
 	// in a successful response, there should be one and only one object
 	if len(response.Vpcs) != 1 {
-		return resource.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.VPCID)
+		return managed.ExternalObservation{}, errors.Errorf(errMultipleItems, cr.Status.VPCID)
 	}
 
 	observed := response.Vpcs[0]
@@ -137,16 +138,16 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (resource.
 
 	cr.UpdateExternalStatus(observed)
 
-	return resource.ExternalObservation{
+	return managed.ExternalObservation{
 		ResourceExists:    true,
-		ConnectionDetails: resource.ConnectionDetails{},
+		ConnectionDetails: managed.ConnectionDetails{},
 	}, nil
 }
 
-func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.ExternalCreation, error) {
+func (e *external) Create(ctx context.Context, mgd resource.Managed) (managed.ExternalCreation, error) {
 	cr, ok := mgd.(*v1alpha3.VPC)
 	if !ok {
-		return resource.ExternalCreation{}, errors.New(errUnexpectedObject)
+		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
 
 	cr.Status.SetConditions(runtimev1alpha1.Creating())
@@ -162,7 +163,7 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 
 		result, err := req.Send()
 		if err != nil {
-			return resource.ExternalCreation{}, errors.Wrap(err, errCreate)
+			return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 		}
 
 		cr.UpdateExternalStatus(*result.Vpc)
@@ -183,18 +184,18 @@ func (e *external) Create(ctx context.Context, mgd resource.Managed) (resource.E
 		attrReq.SetContext(ctx)
 
 		if _, err := attrReq.Send(); err != nil {
-			return resource.ExternalCreation{}, errors.Wrap(err, errModifyVPCAttributes)
+			return managed.ExternalCreation{}, errors.Wrap(err, errModifyVPCAttributes)
 		}
 	}
 
-	return resource.ExternalCreation{ConnectionDetails: resource.ConnectionDetails{}}, nil
+	return managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}, nil
 }
 
-func (e *external) Update(ctx context.Context, mgd resource.Managed) (resource.ExternalUpdate, error) {
+func (e *external) Update(ctx context.Context, mgd resource.Managed) (managed.ExternalUpdate, error) {
 	// TODO(soorena776): add more sophisticated Update logic, once we
 	// categorize immutable vs mutable fields (see #727)
 
-	return resource.ExternalUpdate{}, nil
+	return managed.ExternalUpdate{}, nil
 }
 
 func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {

--- a/pkg/controller/s3/claim.go
+++ b/pkg/controller/s3/claim.go
@@ -29,6 +29,9 @@ import (
 	"github.com/crossplaneio/stack-aws/apis/storage/v1alpha3"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimdefaulting"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimscheduling"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
 )
@@ -61,7 +64,7 @@ func (c *BucketClaimSchedulingController) SetupWithManager(mgr ctrl.Manager) err
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimSchedulingReconciler(mgr,
+		Complete(claimscheduling.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.S3BucketClassGroupVersionKind),
 		))
@@ -88,7 +91,7 @@ func (c *BucketClaimDefaultingController) SetupWithManager(mgr ctrl.Manager) err
 			resource.HasNoClassReference(),
 			resource.HasNoManagedResourceReference(),
 		))).
-		Complete(resource.NewClaimDefaultingReconciler(mgr,
+		Complete(claimdefaulting.NewReconciler(mgr,
 			resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 			resource.ClassKind(v1alpha3.S3BucketClassGroupVersionKind),
 		))
@@ -105,15 +108,15 @@ func (c *BucketClaimController) SetupWithManager(mgr ctrl.Manager) error {
 		v1alpha3.S3BucketKind,
 		v1alpha3.Group))
 
-	r := resource.NewClaimReconciler(mgr,
+	r := claimbinding.NewReconciler(mgr,
 		resource.ClaimKind(storagev1alpha1.BucketGroupVersionKind),
 		resource.ClassKind(v1alpha3.S3BucketClassGroupVersionKind),
 		resource.ManagedKind(v1alpha3.S3BucketGroupVersionKind),
-		resource.WithBinder(resource.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
-		resource.WithManagedConfigurators(
-			resource.ManagedConfiguratorFn(ConfigureS3Bucket),
-			resource.ManagedConfiguratorFn(resource.ConfigureReclaimPolicy),
-			resource.ManagedConfiguratorFn(resource.ConfigureNames),
+		claimbinding.WithBinder(claimbinding.NewAPIBinder(mgr.GetClient(), mgr.GetScheme())),
+		claimbinding.WithManagedConfigurators(
+			claimbinding.ManagedConfiguratorFn(ConfigureS3Bucket),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureReclaimPolicy),
+			claimbinding.ManagedConfiguratorFn(claimbinding.ConfigureNames),
 		))
 
 	p := resource.NewPredicates(resource.AnyOf(

--- a/pkg/controller/s3/claim_test.go
+++ b/pkg/controller/s3/claim_test.go
@@ -29,12 +29,13 @@ import (
 	"github.com/crossplaneio/stack-aws/apis/storage/v1alpha3"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/claimbinding"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
 )
 
-var _ resource.ManagedConfigurator = resource.ManagedConfiguratorFn(ConfigureS3Bucket)
+var _ claimbinding.ManagedConfigurator = claimbinding.ManagedConfiguratorFn(ConfigureS3Bucket)
 
 func TestConfigureBucket(t *testing.T) {
 	type args struct {

--- a/pkg/controller/s3/s3bucket_test.go
+++ b/pkg/controller/s3/s3bucket_test.go
@@ -39,6 +39,7 @@ import (
 	. "github.com/crossplaneio/stack-aws/pkg/clients/s3/fake"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplaneio/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplaneio/crossplane-runtime/pkg/resource"
 	"github.com/crossplaneio/crossplane-runtime/pkg/test"
 	"github.com/crossplaneio/crossplane-runtime/pkg/util"
@@ -96,8 +97,8 @@ func TestSyncBucketError(t *testing.T) {
 
 	assert := func(instance *S3Bucket, client client.Service, expectedResult reconcile.Result, expectedStatus runtimev1alpha1.ConditionedStatus) {
 		r := &Reconciler{
-			Client:                   NewFakeClient(instance),
-			ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(NewFakeClient()),
+			Client:            NewFakeClient(instance),
+			ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
 		}
 
 		rs, err := r._sync(instance, client)
@@ -180,8 +181,8 @@ func TestSyncBucket(t *testing.T) {
 	tr.Status.LastLocalPermission = storagev1alpha1.ReadOnlyPermission
 
 	r := &Reconciler{
-		Client:                   NewFakeClient(tr),
-		ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(NewFakeClient()),
+		Client:            NewFakeClient(tr),
+		ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
 	}
 	//
 	updateBucketACLCalled := false
@@ -213,8 +214,8 @@ func TestDelete(t *testing.T) {
 	tr := testResource()
 
 	r := &Reconciler{
-		Client:                   NewFakeClient(tr),
-		ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(NewFakeClient()),
+		Client:            NewFakeClient(tr),
+		ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
 	}
 
 	cl := &MockS3Client{}
@@ -266,9 +267,9 @@ func TestCreate(t *testing.T) {
 	tr := testResource()
 
 	r := &Reconciler{
-		Client:                     NewFakeClient(tr),
-		ManagedReferenceResolver:   resource.NewAPIManagedReferenceResolver(NewFakeClient()),
-		ManagedConnectionPublisher: resource.PublisherChain{}, // A no-op publisher.
+		Client:              NewFakeClient(tr),
+		ReferenceResolver:   managed.NewAPIReferenceResolver(NewFakeClient()),
+		ConnectionPublisher: managed.PublisherChain{}, // A no-op publisher.
 	}
 
 	createOrUpdateBucketCalled := false
@@ -319,10 +320,10 @@ func TestCreateFail(t *testing.T) {
 
 	testError := errors.New("test-publish-secret-error")
 	r := &Reconciler{
-		Client:                   NewFakeClient(tr),
-		ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(NewFakeClient()),
-		ManagedConnectionPublisher: resource.ManagedConnectionPublisherFns{
-			PublishConnectionFn: func(_ context.Context, _ resource.Managed, _ resource.ConnectionDetails) error {
+		Client:            NewFakeClient(tr),
+		ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
+		ConnectionPublisher: managed.ConnectionPublisherFns{
+			PublishConnectionFn: func(_ context.Context, _ resource.Managed, _ managed.ConnectionDetails) error {
 				return testError
 			},
 		},
@@ -388,8 +389,8 @@ func TestReconcile(t *testing.T) {
 	tr.Status.IAMUsername = ""
 
 	r := &Reconciler{
-		Client:                   NewFakeClient(tr),
-		ManagedReferenceResolver: resource.NewAPIManagedReferenceResolver(NewFakeClient()),
+		Client:            NewFakeClient(tr),
+		ReferenceResolver: managed.NewAPIReferenceResolver(NewFakeClient()),
 	}
 
 	// test connect error


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->


This PR accomplishes the following:
- Updates to Go 1.13.5 by bumping `build` submodule (#104) 
- Updates for usage of new package structure in `crossplane-runtime`
- Updates secret reconciler for multi-propagation (#98)
- Adds new `KubernetesTarget` reconciler

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-aws/blob/master/config/stack/manifests/app.yaml
