### PR TITLE
Rehome deprecated ConditionalStringFormat from crossplane-runtime

### DIFF
--- a/apis/storage/v1alpha3/bucket_types.go
+++ b/apis/storage/v1alpha3/bucket_types.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +27,6 @@ import (
 	storagev1alpha1 "github.com/crossplaneio/crossplane/apis/storage/v1alpha1"
 
 	runtimev1alpha1 "github.com/crossplaneio/crossplane-runtime/apis/core/v1alpha1"
-	"github.com/crossplaneio/crossplane-runtime/pkg/util"
 )
 
 // S3BucketParameters define the desired state of an AWS S3 Bucket.
@@ -155,7 +156,13 @@ type S3BucketClassList struct {
 //   4. NameFormat = "foo-%s", BucketName = "foo-test-uid"
 //   5. NameFormat = "foo-%s-bar-%s", BucketName = "foo-test-uid-bar-%!s(MISSING)"
 func (b *S3Bucket) GetBucketName() string {
-	return util.ConditionalStringFormat(b.Spec.NameFormat, string(b.GetUID()))
+	if b.Spec.NameFormat == "" {
+		return string(b.GetUID())
+	}
+	if strings.Contains(b.Spec.NameFormat, "%s") {
+		return fmt.Sprintf(b.Spec.NameFormat, string(b.GetUID()))
+	}
+	return b.Spec.NameFormat
 }
 
 // SetUserPolicyVersion specifies this bucket's policy version.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
https://github.com/crossplaneio/crossplane-runtime/issues/1

This function and the util package it lives in are deprecated. They'll be replaced by the new crossplane.io/external-name annotation once we port this controller to the managed resource reconciler. For now I'd like to remove it from crossplane-runtime/pkg/util as it is only used by the bucket controllers.

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [ ] Updated any relevant [documentation], [examples], or [release notes].
- [ ] Updated the dependencies in [`app.yaml`] to include any new role permissions.
- [ ] Updated the [stack resources documentation] to include any new managed resources or classes.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
[stack resources documentation]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/resources
